### PR TITLE
Security: Add input validation with Zod

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18,7 +18,8 @@
         "next": "^14.2.35",
         "react": "^18",
         "react-dom": "^18",
-        "react-markdown": "^9.0.1"
+        "react-markdown": "^9.0.1",
+        "zod": "^4.3.6"
       },
       "devDependencies": {
         "@headlessui/tailwindcss": "^0.2.2",
@@ -8375,6 +8376,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/zod": {
+      "version": "4.3.6",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.3.6.tgz",
+      "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
       }
     },
     "node_modules/zwitch": {

--- a/package.json
+++ b/package.json
@@ -19,7 +19,8 @@
     "next": "^14.2.35",
     "react": "^18",
     "react-dom": "^18",
-    "react-markdown": "^9.0.1"
+    "react-markdown": "^9.0.1",
+    "zod": "^4.3.6"
   },
   "devDependencies": {
     "@headlessui/tailwindcss": "^0.2.2",

--- a/src/app/api/tacticus/guildRaid/[season]/route.ts
+++ b/src/app/api/tacticus/guildRaid/[season]/route.ts
@@ -1,6 +1,7 @@
 import { NextResponse } from 'next/server';
 import { adminAuth, adminDb } from '@/lib/firebase/firebaseAdmin';
 import type { DecodedIdToken } from 'firebase-admin/auth';
+import { SeasonParamSchema, validateParams } from '@/lib/validation';
 
 const TACTICUS_SERVER_URL = process.env.TACTICUS_SERVER_URL;
 
@@ -49,7 +50,16 @@ export async function GET(
     request: Request,
     { params }: { params: { season: string } }
 ) {
-    const season = params.season;
+    // Validate season parameter
+    const validation = validateParams(SeasonParamSchema, params);
+    if (!validation.success) {
+        console.log(`[API Route] Invalid season parameter: ${validation.error}`);
+        return NextResponse.json(
+            { type: 'VALIDATION_ERROR', message: validation.error },
+            { status: 400 }
+        );
+    }
+    const { season } = validation.data;
     console.log(`[API Route] Received GET request for guildRaid season: ${season}`);
 
     if (!TACTICUS_SERVER_URL) {

--- a/src/app/api/tacticus/validateKeyAndGetId/route.ts
+++ b/src/app/api/tacticus/validateKeyAndGetId/route.ts
@@ -1,5 +1,6 @@
 import { NextResponse } from 'next/server';
 import type { GuildRaidResponse } from '@/lib/types';
+import { ApiKeyBodySchema, validateParams } from '@/lib/validation';
 
 const TACTICUS_SERVER_URL = process.env.TACTICUS_SERVER_URL;
 
@@ -11,13 +12,14 @@ export async function POST(request: Request) {
         return NextResponse.json({ success: false, error: 'Server configuration error.' }, { status: 500 });
     }
 
-    let apiKey: string | undefined;
+    let apiKey: string;
     try {
         const body = await request.json();
-        apiKey = body.apiKey;
-        if (!apiKey || typeof apiKey !== 'string') {
-            return NextResponse.json({ success: false, error: 'Missing or invalid apiKey in request body.' }, { status: 400 });
+        const validation = validateParams(ApiKeyBodySchema, body);
+        if (!validation.success) {
+            return NextResponse.json({ success: false, error: validation.error }, { status: 400 });
         }
+        apiKey = validation.data.apiKey;
     } catch (error) {
         return NextResponse.json({ success: false, error: 'Invalid request body.' }, { status: 400 });
     }

--- a/src/lib/validation.ts
+++ b/src/lib/validation.ts
@@ -1,0 +1,43 @@
+import { z } from 'zod';
+
+/**
+ * Validation schemas for API endpoints
+ */
+
+// Season parameter validation (e.g., "GR_S17", "GR_S18")
+export const SeasonParamSchema = z.object({
+  season: z
+    .string()
+    .min(1, 'Season parameter is required')
+    .max(20, 'Season parameter too long')
+    .regex(/^GR_S\d+$/, 'Invalid season format. Expected format: GR_S<number>'),
+});
+
+// API Key validation for validateKeyAndGetId endpoint
+export const ApiKeyBodySchema = z.object({
+  apiKey: z
+    .string()
+    .min(1, 'API key is required')
+    .max(100, 'API key too long'),
+});
+
+// Authorization header validation
+export const AuthHeaderSchema = z
+  .string()
+  .min(1, 'Authorization header is required')
+  .startsWith('Bearer ', 'Authorization header must start with "Bearer "');
+
+// Generic validation helper
+export function validateParams<T>(
+  schema: z.ZodSchema<T>,
+  data: unknown
+): { success: true; data: T } | { success: false; error: string } {
+  const result = schema.safeParse(data);
+  if (!result.success) {
+    const errorMessage = result.error.issues
+      .map((e) => e.message)
+      .join(', ');
+    return { success: false, error: errorMessage };
+  }
+  return { success: true, data: result.data };
+}


### PR DESCRIPTION
## Summary
- Added Zod library for schema validation
- Created `src/lib/validation.ts` with reusable validation schemas
- Added validation to endpoints with user input

## Changes
- **New:** `src/lib/validation.ts` - Validation schemas and helper
- **Updated:** `/api/tacticus/guildRaid/[season]` - Validates season format
- **Updated:** `/api/tacticus/validateKeyAndGetId` - Validates API key body

## Validation Rules
| Parameter | Rule | Example |
|-----------|------|---------|
| season | `GR_S<number>` | `GR_S17`, `GR_S18` |
| apiKey | Required, max 100 chars | - |

## Test plan
- [x] `npm run build` succeeds
- [x] Invalid season returns 400 with error message
- [x] Missing API key returns 400 with error message

Closes #18

🤖 Generated with [Claude Code](https://claude.com/claude-code)