### PR TITLE
Hotfix: Correct season parameter validation (fixes #33)

### DIFF
--- a/src/lib/validation.ts
+++ b/src/lib/validation.ts
@@ -4,13 +4,13 @@ import { z } from 'zod';
  * Validation schemas for API endpoints
  */
 
-// Season parameter validation (e.g., "GR_S17", "GR_S18")
+// Season parameter validation (numeric string, e.g., "69", "93")
 export const SeasonParamSchema = z.object({
   season: z
     .string()
     .min(1, 'Season parameter is required')
-    .max(20, 'Season parameter too long')
-    .regex(/^GR_S\d+$/, 'Invalid season format. Expected format: GR_S<number>'),
+    .max(10, 'Season parameter too long')
+    .regex(/^\d+$/, 'Invalid season format. Expected numeric value.'),
 });
 
 // API Key validation for validateKeyAndGetId endpoint


### PR DESCRIPTION
## Summary
- Fix critical bug where season parameter validation was rejecting valid requests
- Changed regex from `^GR_S\d+$` to `^\d+$` to match actual API format

## Problem
All calls to `/api/tacticus/guildRaid/{season}` were failing with HTTP 400:
```json
{"type": "VALIDATION_ERROR", "message": "Invalid season format. Expected format: GR_S<number>"}
```

## Root Cause
The validation in #18 incorrectly assumed the season format was `GR_S<number>`, but the Tacticus API expects plain integers (e.g., `93`).

## Test plan
- [ ] Build passes
- [ ] `/api/tacticus/guildRaid/93` returns valid data

Closes #33

🤖 Generated with [Claude Code](https://claude.ai/claude-code)